### PR TITLE
Correcting a gradient computation flaw that leads to inconsistent outcomes when using non-black background

### DIFF
--- a/submodules/diff-gaussian-rasterization/cuda_rasterizer/backward.cu
+++ b/submodules/diff-gaussian-rasterization/cuda_rasterizer/backward.cu
@@ -512,9 +512,9 @@ PerGaussianRenderCUDA(
 		// TODO: perhaps store these things in shared memory?
 		if (valid_splat && valid_pixel && my_warp.thread_rank() == 0 && idx < BLOCK_SIZE) {
 			T = sampled_T[global_bucket_idx * BLOCK_SIZE + idx];
-			for (int ch = 0; ch < C; ++ch)
-				ar[ch] = -pixel_colors[ch * H * W + pix_id] + sampled_ar[global_bucket_idx * BLOCK_SIZE * C + ch * BLOCK_SIZE + idx];
 			T_final = final_Ts[pix_id];
+			for (int ch = 0; ch < C; ++ch)
+				ar[ch] = -(pixel_colors[ch * H * W + pix_id] - T_final * bg_color[ch]) + sampled_ar[global_bucket_idx * BLOCK_SIZE * C + ch * BLOCK_SIZE + idx];
 			last_contributor = n_contrib[pix_id];
 			for (int ch = 0; ch < C; ++ch) {
 				dL_dpixel[ch] = dL_dpixels[ch * H * W + pix_id];


### PR DESCRIPTION
Thanks for your briliant work! 
I played with this repo multiple times, and it performs exceptionally well when using a black background color. However, when I switched to a white background color for optimization, I noticed that the number of Gaussians ended up nearly double compared to the original 3DGS code.  I dove into the code and found a calculation flaw.
In backward.cu, there is a conversion from _ar_  to _accum_rec_  (from vanilla code) for calculating dL_dalpha, which is 

> _accum_rec_ =  _-ar_  = _pixel_color_ - _sampled_ar_

However, _pixel_color_ also includes the bg_color. The gradient from bg_color is calculated seperately in L550, so we should subtract the background color from _ar_, which is

>  _accum_rec_ =  _-ar_  = (_pixel_color_ - T_final * bg_color) - _sampled_ar_

Current code will exaggrate dL_dalpha when the bg_color is not (0, 0, 0), leading to a significant dL_dmean2D, turns out to cause increased densification.